### PR TITLE
[FLINK-32447][table-planner] Fix missing table hints when they inside…

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -213,6 +213,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlUpdate;
 import org.apache.calcite.sql.SqlUtil;
+import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.util.NlsString;
@@ -1565,8 +1566,10 @@ public class SqlToOperationConverter {
 
     private String getQuotedSqlString(SqlNode sqlNode) {
         SqlParser.Config parserConfig = flinkPlanner.config().getParserConfig();
+        // The default implementation of SqlDialect suppresses all table hints since CALCITE-4640,
+        // so we should use AnsiSqlDialect instead to reserve table hints.
         SqlDialect dialect =
-                new CalciteSqlDialect(
+                new AnsiSqlDialect(
                         SqlDialect.EMPTY_CONTEXT
                                 .withQuotedCasing(parserConfig.unquotedCasing())
                                 .withConformance(parserConfig.conformance())

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hint/OptionsHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hint/OptionsHintTest.xml
@@ -50,29 +50,6 @@ Calc(select=[a, b, (a + 1) AS c])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testOptionsHintOnTableApiView[0: is-bounded=true]">
-    <Resource name="sql">
-      <![CDATA[select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
-+- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
-   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
-   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-MultipleInput(readOrder=[0,1], members=[\nHashJoin(joinType=[InnerJoin], where=[(a = d)], select=[a, b, c, d, e, f], build=[right])\n:- Calc(select=[a, b, (a + 1) AS c])\n:  +- [#2] Exchange(distribution=[hash[a]])\n+- [#1] Exchange(distribution=[hash[d]])\n])
-:- Exchange(distribution=[hash[d]])
-:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
-+- Exchange(distribution=[hash[a]])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]], fields=[a, b])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testJoinWithAppendedOptions[0: is-bounded=true]">
     <Resource name="sql">
       <![CDATA[
@@ -129,6 +106,23 @@ Join(joinType=[InnerJoin], where=[(a = d)], select=[a, b, c, d, e, f], leftInput
 :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2, a.b.c=fakeVal, k5=v5})], dynamic options: {a.b.c=fakeVal, k5=v5}]], fields=[a, b], hints=[[[OPTIONS options:{a.b.c=fakeVal, k5=v5}]]])
 +- Exchange(distribution=[hash[d]])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={d.e.f=fakeVal, k3=v3, k4=v4, k6=v6})], dynamic options: {d.e.f=fakeVal, k6=v6}]], fields=[d, e, f], hints=[[[OPTIONS options:{d.e.f=fakeVal, k6=v6}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverrideOptions[0: is-bounded=true]">
+    <Resource name="sql">
+      <![CDATA[select * from t1/*+ OPTIONS(k1='#v1', k2='#v2') */]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], hints=[[[OPTIONS inheritPath:[] options:{k1=#v1, k2=#v2}]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, (a + 1) AS c])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v1, k2=#v2}]]])
 ]]>
     </Resource>
   </TestCase>
@@ -191,91 +185,28 @@ Join(joinType=[InnerJoin], where=[(a = d)], select=[a, b, c, d, e, f], leftInput
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testOptionsHintOnSQLView[1: is-bounded=false]">
+  <TestCase name="testOptionsHintInsideView[0: is-bounded=true]">
     <Resource name="sql">
-      <![CDATA[select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */]]>
+      <![CDATA[
+select * from t2 join v1 on v1.a = t2.d
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
-+- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
-   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
-   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
+LogicalProject(d=[$0], e=[$1], f=[$2], a=[$3], b=[$4], c=[$5])
++- LogicalJoin(condition=[=($3, $0)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v111, k2=v2, k4=#v444})], dynamic options: {k1=#v111, k4=#v444}]], hints=[[[OPTIONS inheritPath:[] options:{k1=#v111, k4=#v444}]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Join(joinType=[InnerJoin], where=[(a = d)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
-:- Exchange(distribution=[hash[a]])
-:  +- Calc(select=[a, b, (a + 1) AS c])
-:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]], fields=[a, b])
-+- Exchange(distribution=[hash[d]])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testOverrideOptions[0: is-bounded=true]">
-    <Resource name="sql">
-      <![CDATA[select * from t1/*+ OPTIONS(k1='#v1', k2='#v2') */]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], hints=[[[OPTIONS inheritPath:[] options:{k1=#v1, k2=#v2}]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, (a + 1) AS c])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v1, k2=#v2}]]])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testOptionsHintOnSQLView[0: is-bounded=true]">
-    <Resource name="sql">
-      <![CDATA[select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
-+- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
-   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
-   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-MultipleInput(readOrder=[0,1], members=[\nHashJoin(joinType=[InnerJoin], where=[(a = d)], select=[a, b, c, d, e, f], build=[right])\n:- Calc(select=[a, b, (a + 1) AS c])\n:  +- [#2] Exchange(distribution=[hash[a]])\n+- [#1] Exchange(distribution=[hash[d]])\n])
+MultipleInput(readOrder=[1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[(a = d)], select=[d, e, f, a, b, c], build=[right])\n:- [#1] Exchange(distribution=[hash[d]])\n+- Calc(select=[a, b, (a + 1) AS c])\n   +- [#2] Exchange(distribution=[hash[a]])\n])
 :- Exchange(distribution=[hash[d]])
 :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
 +- Exchange(distribution=[hash[a]])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]], fields=[a, b])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testOptionsHintOnTableApiView[1: is-bounded=false]">
-    <Resource name="sql">
-      <![CDATA[select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
-+- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
-   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
-   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Join(joinType=[InnerJoin], where=[(a = d)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
-:- Exchange(distribution=[hash[a]])
-:  +- Calc(select=[a, b, (a + 1) AS c])
-:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]], fields=[a, b])
-+- Exchange(distribution=[hash[d]])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v111, k2=v2, k4=#v444})], dynamic options: {k1=#v111, k4=#v444}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v111, k4=#v444}]]])
 ]]>
     </Resource>
   </TestCase>
@@ -293,6 +224,32 @@ LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
       <![CDATA[
 Calc(select=[a, b, (a + 1) AS c])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v1, k2=#v2}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOptionsHintInsideView[1: is-bounded=false]">
+    <Resource name="sql">
+      <![CDATA[
+select * from t2 join v1 on v1.a = t2.d
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], a=[$3], b=[$4], c=[$5])
++- LogicalJoin(condition=[=($3, $0)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
+   +- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v111, k2=v2, k4=#v444})], dynamic options: {k1=#v111, k4=#v444}]], hints=[[[OPTIONS inheritPath:[] options:{k1=#v111, k4=#v444}]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Join(joinType=[InnerJoin], where=[(a = d)], select=[d, e, f, a, b, c], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:- Exchange(distribution=[hash[d]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
++- Exchange(distribution=[hash[a]])
+   +- Calc(select=[a, b, (a + 1) AS c])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v111, k2=v2, k4=#v444})], dynamic options: {k1=#v111, k4=#v444}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v111, k4=#v444}]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
@@ -179,6 +179,15 @@ class OptionsHintTest(param: Param) extends TableTestBase {
         "cannot be enriched with new options. Hints can only be applied to tables.")
       .isInstanceOf[ValidationException]
   }
+
+  @Test
+  def testOptionsHintInsideView(): Unit = {
+    util.tableEnv.executeSql(
+      "create view v1 as select * from t1 /*+ OPTIONS(k1='#v111', k4='#v444')*/")
+    util.verifyExecPlan(s"""
+                           |select * from t2 join v1 on v1.a = t2.d
+                           |""".stripMargin)
+  }
 }
 
 object OptionsHintTest {


### PR DESCRIPTION
… a view referenced by an external query

This closes #22896

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
