### PR TITLE
refer: init k8s artifact

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ArtifactFetchOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ArtifactFetchOptions.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/** Artifact Fetch options. */
+@PublicEvolving
+public class ArtifactFetchOptions {
+
+    public static final ConfigOption<String> BASE_DIR =
+            ConfigOptions.key("user.artifacts.base-dir")
+                    .stringType()
+                    .defaultValue("/opt/flink/artifacts")
+                    .withDescription("The base dir to put the application job artifacts.");
+
+    public static final ConfigOption<List<String>> ARTIFACT_LIST =
+            key("user.artifacts.artifact-list")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "A semicolon-separated list of the additional artifacts to fetch for the job before setting up the application cluster."
+                                    + " All given elements have to be valid URIs. Example: s3://sandbox-bucket/format.jar;http://sandbox-server:1234/udf.jar");
+
+    public static final ConfigOption<Boolean> RAW_HTTP_ENABLED =
+            ConfigOptions.key("user.artifacts.raw-http-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Enables artifact fetching from raw HTTP endpoints.");
+
+    public static final ConfigOption<Map<String, String>> HTTP_HEADERS =
+            ConfigOptions.key("user.artifacts.http-headers")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Custom HTTP header(s) for the HTTP artifact fetcher. The header(s) will be applied when getting the application job artifacts."
+                                    + " Expected format: headerKey1:headerValue1,headerKey2:headerValue2.");
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/DefaultPackagedProgramRetriever.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DefaultPackagedProgramRetriever.java
@@ -36,12 +36,17 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * {@code PackageProgramRetrieverImpl} is the default implementation of {@link
@@ -124,6 +129,60 @@ public class DefaultPackagedProgramRetriever implements PackagedProgramRetriever
                 entryClassInformationProvider, programArgs, userClasspaths, configuration);
     }
 
+    /**
+     * Creates a {@code PackageProgramRetrieverImpl} with the given parameters.
+     *
+     * @param userLibDir The user library directory that is used for generating the user classpath
+     *     if specified. The system classpath is used if not specified.
+     * @param jarFile The jar archive expected to contain the job class included; {@code null} if
+     *     the job class is on the system classpath.
+     * @param userArtifacts The user artifacts that should be added to the user classpath if
+     *     specified.
+     * @param jobClassName The job class to use; if {@code null} the user classpath (or, if not set,
+     *     the system classpath) will be scanned for possible main class.
+     * @param programArgs The program arguments.
+     * @param configuration The Flink configuration for the given job.
+     * @return The {@code PackageProgramRetrieverImpl} that can be used to create a {@link
+     *     PackagedProgram} instance.
+     * @throws FlinkException If something goes wrong during instantiation.
+     */
+    public static DefaultPackagedProgramRetriever create(
+            @Nullable File userLibDir,
+            @Nullable File jarFile,
+            @Nullable Collection<File> userArtifacts,
+            @Nullable String jobClassName,
+            String[] programArgs,
+            Configuration configuration)
+            throws FlinkException {
+        List<URL> userClasspaths;
+        try {
+            final List<URL> classpathsFromUserLibDir =
+                    getClasspathsFromUserLibDir(userLibDir, jarFile);
+            final List<URL> classpathsFromUserArtifactDir =
+                    getClasspathsFromArtifacts(userArtifacts, jarFile);
+            final List<URL> classpathsFromConfiguration =
+                    getClasspathsFromConfiguration(configuration);
+
+            final List<URL> classpaths = new ArrayList<>();
+            classpaths.addAll(classpathsFromUserLibDir);
+            classpaths.addAll(classpathsFromUserArtifactDir);
+            classpaths.addAll(classpathsFromConfiguration);
+
+            userClasspaths = Collections.unmodifiableList(classpaths);
+        } catch (IOException e) {
+            throw new FlinkException("An error occurred while extracting the user classpath.", e);
+        }
+
+        final EntryClassInformationProvider entryClassInformationProvider =
+                createEntryClassInformationProvider(
+                        (userLibDir == null && userArtifacts == null) ? null : userClasspaths,
+                        jarFile,
+                        jobClassName,
+                        programArgs);
+        return new DefaultPackagedProgramRetriever(
+                entryClassInformationProvider, programArgs, userClasspaths, configuration);
+    }
+
     @VisibleForTesting
     static EntryClassInformationProvider createEntryClassInformationProvider(
             @Nullable Iterable<URL> userClasspath,
@@ -185,13 +244,13 @@ public class DefaultPackagedProgramRetriever implements PackagedProgramRetriever
             List<URL> userClasspath,
             Configuration configuration) {
         this.entryClassInformationProvider =
-                Preconditions.checkNotNull(
+                checkNotNull(
                         entryClassInformationProvider, "No EntryClassInformationProvider passed.");
         this.programArguments =
-                Preconditions.checkNotNull(programArguments, "No program parameter array passed.");
-        this.userClasspath = Preconditions.checkNotNull(userClasspath, "No user classpath passed.");
+                checkNotNull(programArguments, "No program parameter array passed.");
+        this.userClasspath = checkNotNull(userClasspath, "No user classpath passed.");
         this.configuration =
-                Preconditions.checkNotNull(configuration, "No Flink configuration was passed.");
+                checkNotNull(configuration, "No Flink configuration was passed.");
     }
 
     @Override
@@ -238,5 +297,39 @@ public class DefaultPackagedProgramRetriever implements PackagedProgramRetriever
         }
         return ConfigUtils.decodeListFromConfig(
                 configuration, PipelineOptions.CLASSPATHS, URL::new);
+    }
+
+    private static List<URL> getClasspathsFromUserLibDir(
+            @Nullable File userLibDir, @Nullable File jarFile) throws IOException {
+        if (userLibDir == null) {
+            return Collections.emptyList();
+        }
+
+        try (Stream<Path> files = Files.walk(userLibDir.toPath())) {
+            return getClasspathsFromArtifacts(files, jarFile);
+        }
+    }
+
+    private static List<URL> getClasspathsFromArtifacts(
+            @Nullable Collection<File> userArtifacts, @Nullable File jarFile) {
+        if (userArtifacts == null) {
+            return Collections.emptyList();
+        }
+
+        return getClasspathsFromArtifacts(userArtifacts.stream().map(File::toPath), jarFile);
+    }
+
+    private static List<URL> getClasspathsFromArtifacts(
+            Stream<Path> userArtifacts, @Nullable File jarFile) {
+        checkNotNull(userArtifacts);
+
+        final Path workingDirectory = FileUtils.getCurrentWorkingDirectory();
+        final List<URL> relativeJarURLs =
+                userArtifacts
+                        .filter(path -> FileUtils.isJarFile(path) && !path.toFile().equals(jarFile))
+                        .map(path -> FileUtils.relativizePath(workingDirectory, path))
+                        .map(FunctionUtils.uncheckedFunction(FileUtils::toURL))
+                        .collect(Collectors.toList());
+        return Collections.unmodifiableList(relativeJarURLs);
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactFetchManager.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactFetchManager.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.artifact;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.client.cli.ArtifactFetchOptions;
+import org.apache.flink.client.program.DefaultPackagedProgramRetriever;
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.function.FunctionUtils;
+
+import org.apache.commons.io.FilenameUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Class that manages the artifact loading process. */
+public class ArtifactFetchManager {
+
+    private final ArtifactFetcher localFetcher;
+    private final ArtifactFetcher fsFetcher;
+    private final ArtifactFetcher httpFetcher;
+
+    private final Configuration conf;
+    private final File baseDir;
+
+    public ArtifactFetchManager(Configuration conf) {
+        this(conf, null);
+    }
+
+    public ArtifactFetchManager(Configuration conf, @Nullable String baseDir) {
+        this(
+                new LocalArtifactFetcher(),
+                new FsArtifactFetcher(),
+                new HttpArtifactFetcher(),
+                conf,
+                baseDir);
+    }
+
+    @VisibleForTesting
+    ArtifactFetchManager(
+            ArtifactFetcher localFetcher,
+            ArtifactFetcher fsFetcher,
+            ArtifactFetcher httpFetcher,
+            Configuration conf,
+            @Nullable String baseDir) {
+        this.localFetcher = checkNotNull(localFetcher);
+        this.fsFetcher = checkNotNull(fsFetcher);
+        this.httpFetcher = checkNotNull(httpFetcher);
+        this.conf = checkNotNull(conf);
+        this.baseDir =
+                baseDir == null
+                        ? new File(conf.get(ArtifactFetchOptions.BASE_DIR))
+                        : new File(baseDir);
+    }
+
+    /**
+     * Fetches artifacts from a given URI string array. The job jar and any additional artifacts are
+     * mixed, in case of multiple artifacts the {@link DefaultPackagedProgramRetriever} logic will
+     * be used to find the job jar.
+     *
+     * @param uris URIs to fetch
+     * @return result with the fetched artifacts
+     */
+    public Result fetchArtifacts(String[] uris) {
+        checkArgument(uris != null && uris.length > 0, "At least one URI is required.");
+
+        List<File> artifacts =
+                Arrays.stream(uris)
+                        .map(FunctionUtils.uncheckedFunction(this::fetchArtifact))
+                        .collect(Collectors.toList());
+
+        if (artifacts.size() > 1) {
+            return new Result(null, artifacts);
+        }
+
+        if (artifacts.size() == 1) {
+            return new Result(artifacts.get(0), null);
+        }
+
+        // Should not happen.
+        throw new IllegalStateException("Corrupt artifact fetching state.");
+    }
+
+    /**
+     * Fetches the job jar and any additional artifact if the given list is not null or empty.
+     *
+     * @param jobUri URI of the job jar
+     * @param additionalUris URI(s) of any additional artifact to fetch
+     * @return result with the fetched artifacts
+     * @throws Exception
+     */
+    public Result fetchArtifacts(String jobUri, @Nullable List<String> additionalUris)
+            throws Exception {
+        checkArgument(jobUri != null && !jobUri.trim().isEmpty(), "The jobUri is required.");
+
+        File jobJar = fetchArtifact(jobUri);
+        List<File> additionalArtifacts =
+                additionalUris == null
+                        ? Collections.emptyList()
+                        : additionalUris.stream()
+                        .map(FunctionUtils.uncheckedFunction(this::fetchArtifact))
+                        .collect(Collectors.toList());
+
+        return new Result(jobJar, additionalArtifacts);
+    }
+
+    @VisibleForTesting
+    ArtifactFetcher getFetcher(URI uri) {
+        if ("local".equals(uri.getScheme())) {
+            return localFetcher;
+        }
+
+        if (isRawHttp(uri.getScheme()) || "https".equals(uri.getScheme())) {
+            return httpFetcher;
+        }
+
+        return fsFetcher;
+    }
+
+    private File fetchArtifact(String uri) throws Exception {
+        URI resolvedUri = PackagedProgramUtils.resolveURI(uri);
+        File targetFile = new File(baseDir, FilenameUtils.getName(resolvedUri.getPath()));
+        if (targetFile.exists()) {
+            // Already fetched user artifacts are kept.
+            return targetFile;
+        }
+
+        return getFetcher(resolvedUri).fetch(uri, conf, baseDir);
+    }
+
+    private boolean isRawHttp(String uriScheme) {
+        if ("http".equals(uriScheme)) {
+            if (conf.get(ArtifactFetchOptions.RAW_HTTP_ENABLED)) {
+                return true;
+            }
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Artifact fetching from raw HTTP endpoints are disabled. Set the '%s' property to override.",
+                            ArtifactFetchOptions.RAW_HTTP_ENABLED.key()));
+        }
+
+        return false;
+    }
+
+    /** Artifact fetch result with all fetched artifact(s). */
+    public static class Result {
+
+        private final File jobJar;
+        private final List<File> artifacts;
+
+        private Result(@Nullable File jobJar, @Nullable List<File> additionalJars) {
+            this.jobJar = jobJar;
+            this.artifacts = additionalJars == null ? Collections.emptyList() : additionalJars;
+        }
+
+        @Nullable
+        public File getJobJar() {
+            return jobJar;
+        }
+
+        @Nullable
+        public List<File> getArtifacts() {
+            return artifacts.isEmpty() ? null : Collections.unmodifiableList(artifacts);
+        }
+    }
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactFetcher.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactFetcher.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.artifact;
+
+import org.apache.flink.configuration.Configuration;
+
+import java.io.File;
+
+/** Abstract artifact fetcher. */
+abstract class ArtifactFetcher {
+
+    /**
+     * Fetch the resource from the uri to the targetDir.
+     *
+     * @param uri The artifact to be fetched.
+     * @param flinkConfiguration Flink configuration.
+     * @param targetDir The target dir to put the artifact.
+     * @return The path of the fetched artifact.
+     * @throws Exception Error during fetching the artifact.
+     */
+    abstract File fetch(String uri, Configuration flinkConfiguration, File targetDir)
+            throws Exception;
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.artifact;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Artifact fetch related utils. */
+public class ArtifactUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ArtifactUtils.class);
+
+    /**
+     * Creates missing parent directories for the given {@link File} if there are any. Does nothing
+     * otherwise.
+     *
+     * @param baseDir base dir to create parents for
+     */
+    public static synchronized void createMissingParents(File baseDir) {
+        checkNotNull(baseDir, "Base dir has to be provided.");
+
+        if (!baseDir.exists()) {
+            try {
+                FileUtils.forceMkdirParent(baseDir);
+                LOG.info("Created parents for base dir: {}", baseDir);
+            } catch (Exception e) {
+                throw new FlinkRuntimeException(
+                        String.format("Failed to create parent(s) for given base dir: %s", baseDir),
+                        e);
+            }
+        } else {
+            LOG.info("base dir: {} is existed", baseDir);
+        }
+    }
+
+    private ArtifactUtils() {
+        throw new UnsupportedOperationException("This class should never be instantiated.");
+    }
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/FsArtifactFetcher.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/FsArtifactFetcher.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.artifact;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+/** Copies artifact via the Flink filesystem plugin. */
+class FsArtifactFetcher extends ArtifactFetcher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FsArtifactFetcher.class);
+
+    @Override
+    File fetch(String uri, Configuration flinkConf, File targetDir) throws Exception {
+        ArtifactUtils.createMissingParents(targetDir);
+
+        Path source = new Path(uri);
+        long start = System.currentTimeMillis();
+        FileSystem fileSystem = source.getFileSystem();
+        String fileName = source.getName();
+        File targetFile = new File(targetDir, fileName);
+        try (FSDataInputStream inputStream = fileSystem.open(source)) {
+            FileUtils.copyToFile(inputStream, targetFile);
+        }
+        LOG.debug(
+                "Copied file from {} to {}, cost {} ms",
+                source,
+                targetFile,
+                System.currentTimeMillis() - start);
+        return targetFile;
+    }
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/HttpArtifactFetcher.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/HttpArtifactFetcher.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.artifact;
+
+import org.apache.flink.client.cli.ArtifactFetchOptions;
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+
+/** Downloads artifact from an HTTP resource. */
+class HttpArtifactFetcher extends ArtifactFetcher {
+
+    public static final Logger LOG = LoggerFactory.getLogger(HttpArtifactFetcher.class);
+
+    @Override
+    File fetch(String uri, Configuration flinkConf, File targetDir) throws IOException {
+        ArtifactUtils.createMissingParents(targetDir);
+
+        long start = System.currentTimeMillis();
+        URL url = new URL(uri);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        Map<String, String> headers = flinkConf.get(ArtifactFetchOptions.HTTP_HEADERS);
+
+        if (headers != null) {
+            headers.forEach(conn::setRequestProperty);
+        }
+
+        conn.setRequestMethod("GET");
+
+        String fileName = FilenameUtils.getName(url.getPath());
+        File targetFile = new File(targetDir, fileName);
+        try (InputStream inputStream = conn.getInputStream()) {
+            FileUtils.copyToFile(inputStream, targetFile);
+        }
+        LOG.debug(
+                "Copied file from {} to {}, cost {} ms",
+                uri,
+                targetFile,
+                System.currentTimeMillis() - start);
+        return targetFile;
+    }
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/LocalArtifactFetcher.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/LocalArtifactFetcher.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.artifact;
+
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.configuration.Configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+
+/** Retrieves a local artifact as a valid {@link File}. */
+class LocalArtifactFetcher extends ArtifactFetcher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FsArtifactFetcher.class);
+
+    @Override
+    File fetch(String uri, Configuration flinkConf, File targetDir) throws Exception {
+        URI resolvedUri = PackagedProgramUtils.resolveURI(uri);
+        File targetFile = new File(resolvedUri.getPath());
+        LOG.debug("Retrieved local file from {} as {}", uri, targetFile);
+
+        return targetFile;
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.deployment.AbstractContainerizedClusterClientFact
 import org.apache.flink.client.deployment.ClusterClientFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.kubernetes.artifact.DefaultKubernetesArtifactUploader;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
@@ -58,7 +59,8 @@ public class KubernetesClusterClientFactory
         }
         return new KubernetesClusterDescriptor(
                 configuration,
-                FlinkKubeClientFactory.getInstance().fromConfiguration(configuration, "client"));
+                FlinkKubeClientFactory.getInstance(),
+                new DefaultKubernetesArtifactUploader());
     }
 
     @Nullable

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -33,6 +33,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.artifact.KubernetesArtifactUploader;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
@@ -40,6 +41,7 @@ import org.apache.flink.kubernetes.entrypoint.KubernetesApplicationClusterEntryp
 import org.apache.flink.kubernetes.entrypoint.KubernetesSessionClusterEntrypoint;
 import org.apache.flink.kubernetes.kubeclient.Endpoint;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerSpecification;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
@@ -60,6 +62,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
@@ -76,14 +79,20 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
 
     private final FlinkKubeClient client;
 
+    private final KubernetesArtifactUploader artifactUploader;
+
     private final String clusterId;
 
-    public KubernetesClusterDescriptor(Configuration flinkConfig, FlinkKubeClient client) {
+    public KubernetesClusterDescriptor(
+            Configuration flinkConfig,
+            FlinkKubeClientFactory clientFactory,
+            KubernetesArtifactUploader artifactUploader) {
         this.flinkConfig = flinkConfig;
-        this.client = client;
+        this.artifactUploader = artifactUploader;
+        this.client = clientFactory.fromConfiguration(flinkConfig, "client");
         this.clusterId =
                 checkNotNull(
-                        flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID),
+                        flinkConfig.get(KubernetesConfigOptions.CLUSTER_ID),
                         "ClusterId must be specified!");
     }
 
@@ -203,9 +212,15 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
         // No need to do pipelineJars validation if it is a PyFlink job.
         if (!(PackagedProgramUtils.isPython(applicationConfiguration.getApplicationClassName())
                 || PackagedProgramUtils.isPython(applicationConfiguration.getProgramArguments()))) {
-            final List<File> pipelineJars =
+            final List<URI> pipelineJars =
                     KubernetesUtils.checkJarFileForApplicationMode(flinkConfig);
             Preconditions.checkArgument(pipelineJars.size() == 1, "Should only have one jar");
+        }
+
+        try {
+            artifactUploader.uploadAll(flinkConfig);
+        } catch (Exception ex) {
+            throw new ClusterDeploymentException(ex);
         }
 
         final ClusterClientProvider<String> clusterClientProvider =

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/DefaultKubernetesArtifactUploader.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/DefaultKubernetesArtifactUploader.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.artifact;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.client.cli.ArtifactFetchOptions;
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.util.StringUtils;
+import org.apache.flink.util.function.FunctionUtils;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** Default {@link KubernetesArtifactUploader} implementation. */
+public class DefaultKubernetesArtifactUploader implements KubernetesArtifactUploader {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DefaultKubernetesArtifactUploader.class);
+
+    @Override
+    public void uploadAll(Configuration config) throws Exception {
+        if (!config.get(KubernetesConfigOptions.LOCAL_UPLOAD_ENABLED)) {
+            LOG.info(
+                    "Local artifact uploading is disabled. Set '{}' to enable.",
+                    KubernetesConfigOptions.LOCAL_UPLOAD_ENABLED.key());
+            return;
+        }
+
+        final String jobUri = upload(config, getJobUri(config));
+        updateConfig(config, PipelineOptions.JARS, Collections.singletonList(jobUri));
+
+        final List<String> additionalUris =
+                config.getOptional(ArtifactFetchOptions.ARTIFACT_LIST)
+                        .orElse(Collections.emptyList());
+
+        final List<String> uploadedAdditionalUris =
+                additionalUris.stream()
+                        .map(
+                                FunctionUtils.uncheckedFunction(
+                                        artifactUri -> upload(config, artifactUri)))
+                        .collect(Collectors.toList());
+
+        updateConfig(config, ArtifactFetchOptions.ARTIFACT_LIST, uploadedAdditionalUris);
+    }
+
+    @VisibleForTesting
+    String upload(Configuration config, String artifactUriStr)
+            throws IOException, URISyntaxException {
+        final URI artifactUri = PackagedProgramUtils.resolveURI(artifactUriStr);
+        if (!"local".equals(artifactUri.getScheme())) {
+            return artifactUriStr;
+        }
+
+        final String targetDir = config.get(KubernetesConfigOptions.LOCAL_UPLOAD_TARGET);
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(targetDir),
+                String.format(
+                        "Setting '%s' to a valid remote path is required.",
+                        KubernetesConfigOptions.LOCAL_UPLOAD_TARGET.key()));
+
+        final FileSystem.WriteMode writeMode =
+                config.get(KubernetesConfigOptions.LOCAL_UPLOAD_OVERWRITE)
+                        ? FileSystem.WriteMode.OVERWRITE
+                        : FileSystem.WriteMode.NO_OVERWRITE;
+
+        final File src = new File(artifactUri.getPath());
+        final Path target = new Path(targetDir, src.getName());
+        if (target.getFileSystem().exists(target)
+                && writeMode == FileSystem.WriteMode.NO_OVERWRITE) {
+            LOG.info(
+                    "Skip uploading artifact '{}', as it already exists."
+                            + " To overwrite existing artifacts, please set the '{}' config option.",
+                    target,
+                    KubernetesConfigOptions.LOCAL_UPLOAD_OVERWRITE.key());
+        } else {
+            final long start = System.currentTimeMillis();
+            final FileSystem fs = target.getFileSystem();
+            try (FSDataOutputStream os = fs.create(target, writeMode)) {
+                FileUtils.copyFile(src, os);
+            }
+            LOG.debug(
+                    "Copied file from {} to {}, cost {} ms",
+                    src,
+                    target,
+                    System.currentTimeMillis() - start);
+        }
+
+        return target.toString();
+    }
+
+    @VisibleForTesting
+    void updateConfig(
+            Configuration config, ConfigOption<List<String>> configOption, List<String> newValue) {
+        final List<String> originalValue =
+                config.getOptional(configOption).orElse(Collections.emptyList());
+
+        if (hasLocal(originalValue)) {
+            LOG.info(
+                    "Updating configuration '{}' after to replace local artifact: '{}'",
+                    configOption.key(),
+                    newValue);
+            config.set(configOption, newValue);
+        }
+    }
+
+    private String getJobUri(Configuration config) {
+        final List<String> jars = config.get(PipelineOptions.JARS);
+        checkArgument(
+                jars.size() == 1,
+                String.format("The '%s' config must contain one JAR.", PipelineOptions.JARS.key()));
+
+        return config.get(PipelineOptions.JARS).get(0);
+    }
+
+    private boolean hasLocal(List<String> originalUris) {
+        return originalUris.stream().anyMatch(uri -> uri.contains("local:/"));
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/KubernetesArtifactUploader.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/KubernetesArtifactUploader.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.artifact;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.cli.ArtifactFetchOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+
+/** Local artifact uploader for Kubernetes programs. */
+@Internal
+public interface KubernetesArtifactUploader {
+
+    /**
+     * Uploads all {@code local://} schemed artifact that is present, according to the given
+     * configuration. Any remote artifact remains as it was passed originally.
+     *
+     * <p>Takes the job JAR from the {@link PipelineOptions#JARS} config and any additional
+     * artifacts from the {@link ArtifactFetchOptions#ARTIFACT_LIST} config. After the upload,
+     * replaces the URIs of any local JAR in these configs to point to the remotely available one.
+     *
+     * <p>Requires {@link KubernetesConfigOptions#LOCAL_UPLOAD_TARGET} to point to a valid, existing
+     * DFS directory with read and write permissions.
+     *
+     * @param config given Flink configuration
+     * @throws Exception when the upload process fails
+     */
+    void uploadAll(Configuration config) throws Exception;
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -534,6 +534,27 @@ public class KubernetesConfigOptions {
         return "apache/flink:" + tag;
     }
 
+    public static final ConfigOption<Boolean> LOCAL_UPLOAD_ENABLED =
+            ConfigOptions.key("kubernetes.artifacts.local-upload-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Enables uploading 'local://' schemed artifacts to DFS before the the application cluster deployment.");
+
+    public static final ConfigOption<Boolean> LOCAL_UPLOAD_OVERWRITE =
+            ConfigOptions.key("kubernetes.artifacts.local-upload-overwrite")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If enabled, overwrites any existing artifact on the remote target. Disabled by default.");
+
+    public static final ConfigOption<String> LOCAL_UPLOAD_TARGET =
+            ConfigOptions.key("kubernetes.artifacts.local-upload-target")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The target remote DFS directory to upload local artifacts.");
+
+
     /** The flink rest service exposed type. */
     public enum ServiceExposedType {
         ClusterIP(ClusterIPService.INSTANCE),

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
@@ -19,14 +19,17 @@
 package org.apache.flink.kubernetes.entrypoint;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.cli.ArtifactFetchOptions;
 import org.apache.flink.client.deployment.application.ApplicationClusterEntryPoint;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.client.program.DefaultPackagedProgramRetriever;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramRetriever;
 import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.client.program.artifact.ArtifactFetchManager;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypointUtils;
 import org.apache.flink.runtime.entrypoint.DynamicParametersConfigurationParserFactory;
@@ -34,12 +37,14 @@ import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** An {@link ApplicationClusterEntryPoint} for Kubernetes. */
 @Internal
@@ -111,14 +116,39 @@ public final class KubernetesApplicationClusterEntrypoint extends ApplicationClu
         // No need to do pipelineJars validation if it is a PyFlink job.
         if (!(PackagedProgramUtils.isPython(jobClassName)
                 || PackagedProgramUtils.isPython(programArguments))) {
-            final List<File> pipelineJars =
-                    KubernetesUtils.checkJarFileForApplicationMode(configuration);
-            Preconditions.checkArgument(pipelineJars.size() == 1, "Should only have one jar");
+            final ArtifactFetchManager.Result fetchRes = fetchArtifacts(configuration);
             return DefaultPackagedProgramRetriever.create(
-                    userLibDir, pipelineJars.get(0), jobClassName, programArguments, configuration);
+                    userLibDir, fetchRes.getJobJar(),
+                    fetchRes.getArtifacts(), jobClassName, programArguments, configuration);
         }
 
         return DefaultPackagedProgramRetriever.create(
                 userLibDir, jobClassName, programArguments, configuration);
+    }
+
+    private static ArtifactFetchManager.Result fetchArtifacts(Configuration configuration) {
+        try {
+            String targetDir = generateJarDir(configuration);
+            ArtifactFetchManager fetchMgr = new ArtifactFetchManager(configuration, targetDir);
+
+            List<String> uris = configuration.get(PipelineOptions.JARS);
+            checkArgument(uris.size() == 1, "Should only have one jar");
+            List<String> additionalUris =
+                    configuration
+                            .getOptional(ArtifactFetchOptions.ARTIFACT_LIST)
+                            .orElse(Collections.emptyList());
+
+            return fetchMgr.fetchArtifacts(uris.get(0), additionalUris);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static String generateJarDir(Configuration configuration) {
+        return String.join(
+                File.separator,
+                new File(configuration.get(ArtifactFetchOptions.BASE_DIR)).getAbsolutePath(),
+                configuration.get(KubernetesConfigOptions.NAMESPACE),
+                configuration.get(KubernetesConfigOptions.CLUSTER_ID));
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -399,20 +399,9 @@ public class KubernetesUtils {
         return Arrays.asList("bash", "-c", command);
     }
 
-    public static List<File> checkJarFileForApplicationMode(Configuration configuration) {
+    public static List<URI> checkJarFileForApplicationMode(Configuration configuration) {
         return configuration.get(PipelineOptions.JARS).stream()
-                .map(
-                        FunctionUtils.uncheckedFunction(
-                                uri -> {
-                                    final URI jarURI = PackagedProgramUtils.resolveURI(uri);
-                                    if (jarURI.getScheme().equals("local") && jarURI.isAbsolute()) {
-                                        return new File(jarURI.getPath());
-                                    }
-                                    throw new IllegalArgumentException(
-                                            "Only \"local\" is supported as schema for application mode."
-                                                    + " This assumes that the jar is located in the image, not the Flink client."
-                                                    + " An example of such path is: local:///opt/flink/examples/streaming/WindowJoin.jar");
-                                }))
+                .map(FunctionUtils.uncheckedFunction(PackagedProgramUtils::resolveURI))
                 .collect(Collectors.toList());
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -24,14 +24,19 @@ import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.artifact.DefaultKubernetesArtifactUploader;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
+import org.apache.flink.kubernetes.kubeclient.Fabric8FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
@@ -44,6 +49,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.Executors;
 
 import static org.apache.flink.kubernetes.utils.Constants.ENV_FLINK_POD_IP_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,7 +75,17 @@ class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
     protected void onSetup() throws Exception {
         super.onSetup();
 
-        descriptor = new KubernetesClusterDescriptor(flinkConfig, flinkKubeClient);
+        descriptor = new KubernetesClusterDescriptor(flinkConfig,  new FlinkKubeClientFactory() {
+            @Override
+            public FlinkKubeClient fromConfiguration(
+                    Configuration flinkConfig, String useCase) {
+                return new Fabric8FlinkKubeClient(
+                        flinkConfig,
+                        server.getClient().inNamespace(NAMESPACE),
+                        Executors.newSingleThreadScheduledExecutor());
+            }
+        },
+                new DefaultKubernetesArtifactUploader());
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
