### PR TITLE
merge 1.17.0 k8s bugfix 

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -53,6 +53,8 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import io.fabric8.kubernetes.client.KubernetesClientException;
+
 import javax.annotation.Nullable;
 
 import java.io.File;
@@ -64,6 +66,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /** Implementation of {@link ResourceManagerDriver} for Kubernetes deployment. */
 public class KubernetesResourceManagerDriver
@@ -219,6 +222,10 @@ public class KubernetesResourceManagerDriver
                             if (t == null) {
                                 return null;
                             }
+                            // Unwrap CompletionException cause if any
+                            if (t instanceof CompletionException && t.getCause() != null) {
+                                t = t.getCause();
+                            }
                             if (t instanceof CancellationException) {
 
                                 requestResourceFutures.remove(taskManagerPod.getName());
@@ -228,8 +235,9 @@ public class KubernetesResourceManagerDriver
                                             podName);
                                     stopPod(taskManagerPod.getName());
                                 }
-                            } else if (t instanceof RetryableException) {
-                                // ignore
+                            } else if (t instanceof RetryableException
+                                    || t instanceof KubernetesClientException) {
+                                // ignore transient / retriable errors
                             } else {
                                 log.error("Error completing resource request.", t);
                                 ExceptionUtils.rethrow(t);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
@@ -44,8 +44,8 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_ADDRESS_KEY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_SESSION_ID_KEY;
-import static org.apache.flink.kubernetes.utils.KubernetesUtils.checkConfigMaps;
 import static org.apache.flink.kubernetes.utils.KubernetesUtils.getLeaderInformationFromConfigMap;
+import static org.apache.flink.kubernetes.utils.KubernetesUtils.getOnlyConfigMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -216,7 +216,7 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
         @Override
         public void onModified(List<KubernetesConfigMap> configMaps) {
             // We should only receive events for the watched ConfigMap
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
 
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 leaderElectionEventHandler.onLeaderInformationChange(
@@ -226,7 +226,7 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
 
         @Override
         public void onDeleted(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             // The ConfigMap is deleted externally.
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 fatalErrorHandler.onFatalError(
@@ -237,7 +237,7 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
 
         @Override
         public void onError(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 fatalErrorHandler.onFatalError(
                         new LeaderElectionException(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
@@ -49,8 +49,6 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
     private static final Logger LOG =
             LoggerFactory.getLogger(KubernetesLeaderRetrievalDriver.class);
 
-    private final FlinkKubeClient kubeClient;
-
     private final String configMapName;
 
     private final LeaderRetrievalEventHandler leaderRetrievalEventHandler;
@@ -64,14 +62,12 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
     private final Function<KubernetesConfigMap, LeaderInformation> leaderInformationExtractor;
 
     public KubernetesLeaderRetrievalDriver(
-            FlinkKubeClient kubeClient,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
             Executor watchExecutor,
             String configMapName,
             LeaderRetrievalEventHandler leaderRetrievalEventHandler,
             Function<KubernetesConfigMap, LeaderInformation> leaderInformationExtractor,
             FatalErrorHandler fatalErrorHandler) {
-        this.kubeClient = checkNotNull(kubeClient, "Kubernetes client");
         this.configMapName = checkNotNull(configMapName, "ConfigMap name");
         this.leaderRetrievalEventHandler =
                 checkNotNull(leaderRetrievalEventHandler, "LeaderRetrievalEventHandler");

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
@@ -98,9 +98,14 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
 
         @Override
         public void onAdded(List<KubernetesConfigMap> configMaps) {
-            // The ConfigMap is created by KubernetesLeaderElectionDriver with empty data. We do not
-            // process this
-            // useless event.
+            // The ConfigMap is created by KubernetesLeaderElectionDriver with empty data. We don't
+            // really need to process anything unless the retriever was started after the leader
+            // election has already succeeded.
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
+            final LeaderInformation leaderInformation = leaderInformationExtractor.apply(configMap);
+            if (!leaderInformation.isEmpty()) {
+                leaderRetrievalEventHandler.notifyLeaderAddress(leaderInformation);
+            }
         }
 
         @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
-import static org.apache.flink.kubernetes.utils.KubernetesUtils.checkConfigMaps;
+import static org.apache.flink.kubernetes.utils.KubernetesUtils.getOnlyConfigMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -105,7 +105,7 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
 
         @Override
         public void onModified(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             leaderRetrievalEventHandler.notifyLeaderAddress(
                     leaderInformationExtractor.apply(configMap));
         }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.kubernetes.highavailability;
 
-import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriverFactory;
@@ -35,19 +34,15 @@ import java.util.concurrent.Executor;
 @Deprecated
 public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDriverFactory {
 
-    private final FlinkKubeClient kubeClient;
-
     private final KubernetesConfigMapSharedWatcher configMapSharedWatcher;
     private final Executor watchExecutor;
 
     private final String configMapName;
 
     public KubernetesLeaderRetrievalDriverFactory(
-            FlinkKubeClient kubeClient,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
             Executor watchExecutor,
             String configMapName) {
-        this.kubeClient = kubeClient;
         this.configMapSharedWatcher = configMapSharedWatcher;
         this.watchExecutor = watchExecutor;
         this.configMapName = configMapName;
@@ -57,7 +52,6 @@ public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDr
     public KubernetesLeaderRetrievalDriver createLeaderRetrievalDriver(
             LeaderRetrievalEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler) {
         return new KubernetesLeaderRetrievalDriver(
-                kubeClient,
                 configMapSharedWatcher,
                 watchExecutor,
                 configMapName,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
-import static org.apache.flink.kubernetes.utils.KubernetesUtils.checkConfigMaps;
+import static org.apache.flink.kubernetes.utils.KubernetesUtils.getOnlyConfigMap;
 
 /** {@link MultipleComponentLeaderElectionDriver} for Kubernetes. */
 public class KubernetesMultipleComponentLeaderElectionDriver
@@ -229,7 +229,7 @@ public class KubernetesMultipleComponentLeaderElectionDriver
 
         @Override
         public void onModified(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
 
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 Collection<LeaderInformationWithComponentId> leaderInformationWithLeaderNames =
@@ -242,7 +242,7 @@ public class KubernetesMultipleComponentLeaderElectionDriver
 
         @Override
         public void onDeleted(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 fatalErrorHandler.onFatalError(
                         new LeaderElectionException(
@@ -254,7 +254,7 @@ public class KubernetesMultipleComponentLeaderElectionDriver
 
         @Override
         public void onError(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 fatalErrorHandler.onFatalError(
                         new LeaderElectionException(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
@@ -52,7 +52,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.Constants.NAME_SEPARATOR;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -95,9 +94,7 @@ public class KubernetesMultipleComponentLeaderElectionHaServices extends Abstrac
         this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
 
         this.configMapSharedWatcher =
-                this.kubeClient.createConfigMapSharedWatcher(
-                        KubernetesUtils.getConfigMapLabels(
-                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+                this.kubeClient.createConfigMapSharedWatcher(getClusterConfigMap());
         this.watchExecutorService =
                 Executors.newCachedThreadPool(
                         new ExecutorThreadFactory("config-map-watch-handler"));
@@ -216,11 +213,7 @@ public class KubernetesMultipleComponentLeaderElectionHaServices extends Abstrac
             exception = e;
         }
 
-        kubeClient
-                .deleteConfigMapsByLabels(
-                        KubernetesUtils.getConfigMapLabels(
-                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY))
-                .get();
+        kubeClient.deleteConfigMap(getClusterConfigMap()).get();
 
         ExceptionUtils.tryRethrowException(exception);
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderRetrievalDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderRetrievalDriverFactory.java
@@ -66,7 +66,6 @@ public class KubernetesMultipleComponentLeaderRetrievalDriverFactory
     public LeaderRetrievalDriver createLeaderRetrievalDriver(
             LeaderRetrievalEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler) {
         return new KubernetesLeaderRetrievalDriver(
-                kubeClient,
                 configMapSharedWatcher,
                 watchExecutor,
                 configMapName,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -333,15 +333,6 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public CompletableFuture<Void> deleteConfigMapsByLabels(Map<String, String> labels) {
-        // the only time, the delete method returns false is due to a 404 HTTP status which is
-        // returned if the underlying resource doesn't exist
-        return CompletableFuture.runAsync(
-                () -> this.internalClient.configMaps().withLabels(labels).delete(),
-                kubeClientExecutorService);
-    }
-
-    @Override
     public CompletableFuture<Void> deleteConfigMap(String configMapName) {
         // the only time, the delete method returns false is due to a 404 HTTP status which is
         // returned if the underlying resource doesn't exist
@@ -351,9 +342,9 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(
-            Map<String, String> labels) {
-        return new KubernetesConfigMapSharedInformer(this.internalClient, labels);
+    public KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(String name) {
+        LOG.info("Creating configmap shared watcher for {}.", name);
+        return new KubernetesConfigMapSharedInformer(this.internalClient, name);
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -165,16 +165,6 @@ public interface FlinkKubeClient extends AutoCloseable {
             Function<KubernetesConfigMap, Optional<KubernetesConfigMap>> updateFunction);
 
     /**
-     * Delete the Kubernetes ConfigMaps by labels. This will be used by the HA service to clean up
-     * all data.
-     *
-     * @param labels labels to filter the resources. e.g. type: high-availability
-     * @return Return the delete future that only completes successfully, if the resources that are
-     *     subject to deletion are actually gone.
-     */
-    CompletableFuture<Void> deleteConfigMapsByLabels(Map<String, String> labels);
-
-    /**
      * Delete a Kubernetes ConfigMap by name.
      *
      * @param configMapName ConfigMap name
@@ -183,13 +173,12 @@ public interface FlinkKubeClient extends AutoCloseable {
     CompletableFuture<Void> deleteConfigMap(String configMapName);
 
     /**
-     * Create a shared watcher for ConfigMaps with specified labels.
+     * Create a shared watcher for ConfigMaps with specified name.
      *
-     * @param labels labels to filter ConfigMaps. If the labels is null or empty, all ConfigMaps
-     *     will be taken in account, or it will be rejected if the implementation does not allow it.
+     * @param name name of the ConfigMap to watch.
      * @return Return a shared watcher.
      */
-    KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(Map<String, String> labels);
+    KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(String name);
 
     /** Close the Kubernetes client with no exception. */
     void close();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesConfigMapSharedInformer.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesConfigMapSharedInformer.java
@@ -19,29 +19,26 @@
 package org.apache.flink.kubernetes.kubeclient.resources;
 
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
-import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Informable;
-
-import java.util.Map;
 
 /** The shared informer for {@link ConfigMap}, it can be used as a shared watcher. */
 public class KubernetesConfigMapSharedInformer
         extends KubernetesSharedInformer<ConfigMap, KubernetesConfigMap>
         implements KubernetesConfigMapSharedWatcher {
 
-    public KubernetesConfigMapSharedInformer(
-            NamespacedKubernetesClient client, Map<String, String> labels) {
-        super(client, getInformableConfigMaps(client, labels), KubernetesConfigMap::new);
+    public KubernetesConfigMapSharedInformer(NamespacedKubernetesClient client, String name) {
+        super(client, getInformabaleConfigMaps(client, name), KubernetesConfigMap::new);
     }
 
-    private static Informable<ConfigMap> getInformableConfigMaps(
-            NamespacedKubernetesClient client, Map<String, String> labels) {
+    private static Informable<ConfigMap> getInformabaleConfigMaps(
+            NamespacedKubernetesClient client, String name) {
         Preconditions.checkArgument(
-                !CollectionUtil.isNullOrEmpty(labels), "Labels must not be null or empty");
-        return client.configMaps().withLabels(labels);
+                !StringUtils.isNullOrWhitespaceOnly(name), "Name must not be null or empty");
+        return client.configMaps().withName(name);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -209,11 +209,15 @@ public class KubernetesUtils {
      * @param expectedConfigMapName expected ConfigMap Name
      * @return Return the expected ConfigMap
      */
-    public static KubernetesConfigMap checkConfigMaps(
+    public static KubernetesConfigMap getOnlyConfigMap(
             List<KubernetesConfigMap> configMaps, String expectedConfigMapName) {
-        assert (configMaps.size() == 1);
-        assert (configMaps.get(0).getName().equals(expectedConfigMapName));
-        return configMaps.get(0);
+        if (configMaps.size() == 1 && expectedConfigMapName.equals(configMaps.get(0).getName())) {
+            return configMaps.get(0);
+        }
+        throw new IllegalStateException(
+                String.format(
+                        "ConfigMap list should only contain a single ConfigMap [%s].",
+                        expectedConfigMapName));
     }
 
     /**

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -159,7 +159,7 @@ class KubernetesCheckpointIDCounterTest extends KubernetesHighAvailabilityTestBa
                                                     checkpointIDCounter
                                                             .shutdown(JobStatus.FINISHED)
                                                             .get())
-                                    .satisfies(anyCauseMatches(CompletionException.class));
+                                    .satisfies(anyCauseMatches(ExecutionException.class));
 
                             // fixing the internal issue should make the shutdown succeed again
                             KubernetesUtils.createConfigMapIfItDoesNotExist(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -162,7 +162,6 @@ class KubernetesHighAvailabilityTestBase {
         private LeaderRetrievalDriver createLeaderRetrievalDriver() {
             final KubernetesLeaderRetrievalDriverFactory factory =
                     new KubernetesLeaderRetrievalDriverFactory(
-                            flinkKubeClient,
                             kubernetesTestFixture.getConfigMapSharedWatcher(),
                             watchCallbackExecutorService,
                             LEADER_CONFIGMAP_NAME);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -35,7 +35,6 @@ import org.apache.flink.util.function.RunnableWithException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -83,7 +82,6 @@ class KubernetesHighAvailabilityTestBase {
         final Configuration configuration;
 
         final CompletableFuture<Void> closeKubeClientFuture;
-        final CompletableFuture<Map<String, String>> deleteConfigMapByLabelsFuture;
 
         Context() {
             kubernetesTestFixture =
@@ -91,8 +89,6 @@ class KubernetesHighAvailabilityTestBase {
             flinkKubeClient = kubernetesTestFixture.getFlinkKubeClient();
             configuration = kubernetesTestFixture.getConfiguration();
             closeKubeClientFuture = kubernetesTestFixture.getCloseKubeClientFuture();
-            deleteConfigMapByLabelsFuture =
-                    kubernetesTestFixture.getDeleteConfigMapByLabelsFuture();
             electionEventHandler = new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
             leaderElectionDriver = createLeaderElectionDriver();
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.kubernetes.highavailability;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.KubernetesExtension;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesHighAvailabilityOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesLeaderElectionConfiguration;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
@@ -28,15 +29,18 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionEventHandler;
 import org.apache.flink.runtime.leaderretrieval.TestingLeaderRetrievalEventHandler;
-import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,73 +58,99 @@ class KubernetesLeaderElectionAndRetrievalITCase {
             "akka.tcp://flink@172.20.1.21:6123/user/rpc/dispatcher";
 
     @RegisterExtension
-    private static final KubernetesExtension kubernetesExtension = new KubernetesExtension();
+    private static final KubernetesExtension KUBERNETES_EXTENSION = new KubernetesExtension();
+
+    @RegisterExtension
+    private static final TestExecutorExtension<ExecutorService> EXECUTOR_EXTENSION =
+            new TestExecutorExtension<>(Executors::newCachedThreadPool);
 
     @Test
     void testLeaderElectionAndRetrieval() throws Exception {
-        final String configMapName = LEADER_CONFIGMAP_NAME + System.currentTimeMillis();
-        KubernetesLeaderElectionDriver leaderElectionDriver = null;
-        KubernetesLeaderRetrievalDriver leaderRetrievalDriver = null;
-
-        final FlinkKubeClient flinkKubeClient = kubernetesExtension.getFlinkKubeClient();
-        final Configuration configuration = kubernetesExtension.getConfiguration();
+        final String configMapName = LEADER_CONFIGMAP_NAME + UUID.randomUUID();
+        final FlinkKubeClient flinkKubeClient = KUBERNETES_EXTENSION.getFlinkKubeClient();
+        final Configuration configuration = KUBERNETES_EXTENSION.getConfiguration();
 
         final String clusterId = configuration.getString(KubernetesConfigOptions.CLUSTER_ID);
+
+        // This will make the leader election retrieval time out if we won't process already
+        // existing leader information when starting it up.
+        configuration.set(
+                KubernetesHighAvailabilityOptions.KUBERNETES_LEASE_DURATION, Duration.ofHours(1));
+        configuration.set(
+                KubernetesHighAvailabilityOptions.KUBERNETES_RETRY_PERIOD, Duration.ofHours(1));
+        configuration.set(
+                KubernetesHighAvailabilityOptions.KUBERNETES_RENEW_DEADLINE, Duration.ofHours(1));
+
+        final List<AutoCloseable> closeables = new ArrayList<>();
+
         final KubernetesConfigMapSharedWatcher configMapSharedWatcher =
                 flinkKubeClient.createConfigMapSharedWatcher(
                         KubernetesUtils.getConfigMapLabels(
                                 clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
-        final ExecutorService watchExecutorService = Executors.newCachedThreadPool();
+        closeables.add(configMapSharedWatcher);
 
         final TestingLeaderElectionEventHandler electionEventHandler =
                 new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
+        closeables.add(electionEventHandler);
 
         try {
-            leaderElectionDriver =
+            final KubernetesLeaderElectionDriver leaderElectionDriver =
                     new KubernetesLeaderElectionDriver(
                             flinkKubeClient,
                             configMapSharedWatcher,
-                            watchExecutorService,
+                            EXECUTOR_EXTENSION.getExecutor(),
                             new KubernetesLeaderElectionConfiguration(
                                     configMapName, UUID.randomUUID().toString(), configuration),
                             electionEventHandler,
                             electionEventHandler::handleError);
+            closeables.add(leaderElectionDriver);
+
             electionEventHandler.init(leaderElectionDriver);
 
-            final TestingLeaderRetrievalEventHandler retrievalEventHandler =
-                    new TestingLeaderRetrievalEventHandler();
-            leaderRetrievalDriver =
-                    new KubernetesLeaderRetrievalDriver(
-                            configMapSharedWatcher,
-                            watchExecutorService,
-                            configMapName,
-                            retrievalEventHandler,
-                            KubernetesUtils::getLeaderInformationFromConfigMap,
-                            retrievalEventHandler::handleError);
+            final Function<TestingLeaderRetrievalEventHandler, AutoCloseable>
+                    leaderRetrievalDriverFactory =
+                            leaderRetrievalEventHandler ->
+                                    new KubernetesLeaderRetrievalDriver(
+                                            configMapSharedWatcher,
+                                            EXECUTOR_EXTENSION.getExecutor(),
+                                            configMapName,
+                                            leaderRetrievalEventHandler,
+                                            KubernetesUtils::getLeaderInformationFromConfigMap,
+                                            leaderRetrievalEventHandler::handleError);
 
+            final TestingLeaderRetrievalEventHandler firstLeaderRetrievalEventHandler =
+                    new TestingLeaderRetrievalEventHandler();
+            closeables.add(leaderRetrievalDriverFactory.apply(firstLeaderRetrievalEventHandler));
+
+            // Wait for the driver to obtain leadership.
             electionEventHandler.waitForLeader();
-            // Check the new leader is confirmed
             final LeaderInformation confirmedLeaderInformation =
                     electionEventHandler.getConfirmedLeaderInformation();
             assertThat(confirmedLeaderInformation.getLeaderAddress()).isEqualTo(LEADER_ADDRESS);
 
-            // Check the leader retrieval driver should be notified the leader address
-            retrievalEventHandler.waitForNewLeader();
-            assertThat(retrievalEventHandler.getLeaderSessionID())
-                    .isEqualByComparingTo(confirmedLeaderInformation.getLeaderSessionID());
-            assertThat(retrievalEventHandler.getAddress())
-                    .isEqualTo(confirmedLeaderInformation.getLeaderAddress());
+            // Check if the leader retrieval driver is notified about the leader address
+            awaitLeadership(firstLeaderRetrievalEventHandler, confirmedLeaderInformation);
+
+            // Start a second leader retrieval that should be notified immediately because we
+            // already know who the leader is.
+            final TestingLeaderRetrievalEventHandler secondRetrievalEventHandler =
+                    new TestingLeaderRetrievalEventHandler();
+            closeables.add(leaderRetrievalDriverFactory.apply(secondRetrievalEventHandler));
+            awaitLeadership(secondRetrievalEventHandler, confirmedLeaderInformation);
         } finally {
-            electionEventHandler.close();
-            if (leaderElectionDriver != null) {
-                leaderElectionDriver.close();
-            }
-            if (leaderRetrievalDriver != null) {
-                leaderRetrievalDriver.close();
+            for (AutoCloseable closeable : closeables) {
+                closeable.close();
             }
             flinkKubeClient.deleteConfigMap(configMapName).get();
-            configMapSharedWatcher.close();
-            ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, watchExecutorService);
         }
+    }
+
+    private static void awaitLeadership(
+            TestingLeaderRetrievalEventHandler handler, LeaderInformation leaderInformation)
+            throws Exception {
+        handler.waitForNewLeader();
+        assertThat(handler.getLeaderSessionID())
+                .isEqualByComparingTo(leaderInformation.getLeaderSessionID());
+        assertThat(handler.getAddress()).isEqualTo(leaderInformation.getLeaderAddress());
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -91,7 +91,6 @@ class KubernetesLeaderElectionAndRetrievalITCase {
                     new TestingLeaderRetrievalEventHandler();
             leaderRetrievalDriver =
                     new KubernetesLeaderRetrievalDriver(
-                            flinkKubeClient,
                             configMapSharedWatcher,
                             watchExecutorService,
                             configMapName,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -84,9 +83,7 @@ class KubernetesLeaderElectionAndRetrievalITCase {
         final List<AutoCloseable> closeables = new ArrayList<>();
 
         final KubernetesConfigMapSharedWatcher configMapSharedWatcher =
-                flinkKubeClient.createConfigMapSharedWatcher(
-                        KubernetesUtils.getConfigMapLabels(
-                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+                flinkKubeClient.createConfigMapSharedWatcher(configMapName);
         closeables.add(configMapSharedWatcher);
 
         final TestingLeaderElectionEventHandler electionEventHandler =

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.kubernetes.highavailability;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
+import org.apache.flink.runtime.leaderelection.LeaderElectionException;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 
 import org.junit.jupiter.api.Test;
@@ -28,7 +30,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.apache.flink.core.testutils.FlinkAssertions.assertThatChainOfCauses;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_KEY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_ADDRESS_KEY;
@@ -91,9 +92,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             electionEventHandler.waitForError();
                             final String errorMsg =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " does not exist.";
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(KubernetesException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };
@@ -136,9 +137,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                                     "Could not write leader information since ConfigMap "
                                             + LEADER_CONFIGMAP_NAME
                                             + " does not exist.";
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(KubernetesException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };
@@ -199,9 +200,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             electionEventHandler.waitForError();
                             final String errorMsg =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " is deleted externally";
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(LeaderElectionException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };
@@ -223,9 +224,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             electionEventHandler.waitForError();
                             final String errorMsg =
                                     "Error while watching the ConfigMap " + LEADER_CONFIGMAP_NAME;
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(LeaderElectionException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
@@ -561,9 +561,9 @@ class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTestBase 
                             final FlinkKubeClient anotherFlinkKubeClient =
                                     createFlinkKubeClientBuilder()
                                             .setCheckAndUpdateConfigMapFunction(
-                                                    (configMapName, function) -> {
-                                                        throw updateException;
-                                                    })
+                                                    (configMapName, function) ->
+                                                            FutureUtils.completedExceptionally(
+                                                                    updateException))
                                             .build();
                             final KubernetesStateHandleStore<
                                             TestingLongStateHandleHelper.LongStateHandle>

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector.LEADER_ANNOTATION_KEY;
@@ -167,10 +166,10 @@ class KubernetesTestFixture {
                                                     .orElse(false);
                                     return CompletableFuture.completedFuture(updated);
                                 } catch (Throwable throwable) {
-                                    throw new CompletionException(throwable);
+                                    return FutureUtils.completedExceptionally(throwable);
                                 }
                             }
-                            throw new CompletionException(
+                            return FutureUtils.completedExceptionally(
                                     new KubernetesException(
                                             "ConfigMap " + configMapName + " does not exist."));
                         })

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
@@ -26,7 +26,6 @@ import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
-import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import java.util.ArrayList;
@@ -38,7 +37,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector.LEADER_ANNOTATION_KEY;
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test fixture for Kubernetes tests that sets up a mock {@link FlinkKubeClient}. */
@@ -58,8 +56,6 @@ class KubernetesTestFixture {
     private final List<TestingFlinkKubeClient.MockKubernetesWatch> configMapWatches =
             new ArrayList<>();
 
-    private final CompletableFuture<Map<String, String>> deleteConfigMapByLabelsFuture =
-            new CompletableFuture<>();
     private final CompletableFuture<Void> closeKubeClientFuture = new CompletableFuture<>();
 
     private final CompletableFuture<KubernetesLeaderElector.LeaderCallbackHandler>
@@ -76,10 +72,7 @@ class KubernetesTestFixture {
         configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
 
         flinkKubeClient = createFlinkKubeClient();
-        configMapSharedWatcher =
-                flinkKubeClient.createConfigMapSharedWatcher(
-                        KubernetesUtils.getConfigMapLabels(
-                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+        configMapSharedWatcher = flinkKubeClient.createConfigMapSharedWatcher(leaderConfigmapName);
     }
 
     void close() {
@@ -92,10 +85,6 @@ class KubernetesTestFixture {
 
     CompletableFuture<Void> getCloseKubeClientFuture() {
         return closeKubeClientFuture;
-    }
-
-    CompletableFuture<Map<String, String>> getDeleteConfigMapByLabelsFuture() {
-        return deleteConfigMapByLabelsFuture;
     }
 
     KubernetesConfigMapSharedWatcher getConfigMapSharedWatcher() {
@@ -178,19 +167,6 @@ class KubernetesTestFixture {
                             configMapStore.remove(name);
                             return FutureUtils.completedVoidFuture();
                         })
-                .setDeleteConfigMapByLabelFunction(
-                        labels -> {
-                            if (deleteConfigMapByLabelsFuture.isDone()) {
-                                return FutureUtils.completedExceptionally(
-                                        new KubernetesException(
-                                                "ConfigMap with labels "
-                                                        + labels
-                                                        + " has already be deleted."));
-                            } else {
-                                deleteConfigMapByLabelsFuture.complete(labels);
-                                return FutureUtils.completedVoidFuture();
-                            }
-                        })
                 .setCloseConsumer(closeKubeClientFuture::complete)
                 .setCreateLeaderElectorFunction(
                         (leaderConfig, callbackHandler) -> {
@@ -199,12 +175,11 @@ class KubernetesTestFixture {
                                     leaderConfig, callbackHandler);
                         })
                 .setCreateConfigMapSharedWatcherFunction(
-                        (labels) -> {
+                        name -> {
                             final TestingFlinkKubeClient.TestingKubernetesConfigMapSharedWatcher
                                     watcher =
                                             new TestingFlinkKubeClient
-                                                    .TestingKubernetesConfigMapSharedWatcher(
-                                                    labels);
+                                                    .TestingKubernetesConfigMapSharedWatcher(name);
                             watcher.setWatchFunction(
                                     (ignore, handler) -> {
                                         final CompletableFuture<

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -448,21 +448,6 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
     }
 
     @Test
-    void testDeleteConfigMapByLabels() throws Exception {
-        this.flinkKubeClient.createConfigMap(buildTestingConfigMap()).get();
-        assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isPresent();
-        this.flinkKubeClient.deleteConfigMapsByLabels(TESTING_LABELS).get();
-        assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isNotPresent();
-    }
-
-    @Test
-    void testDeleteNotExistingConfigMapByLabels() throws Exception {
-        assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isNotPresent();
-        this.flinkKubeClient.deleteConfigMapsByLabels(TESTING_LABELS).get();
-        assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isNotPresent();
-    }
-
-    @Test
     void testDeleteConfigMapByName() throws Exception {
         this.flinkKubeClient.createConfigMap(buildTestingConfigMap()).get();
         assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isPresent();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -61,8 +61,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                     Function<KubernetesConfigMap, Optional<KubernetesConfigMap>>,
                     CompletableFuture<Boolean>>
             checkAndUpdateConfigMapFunction;
-    private final Function<Map<String, String>, CompletableFuture<Void>>
-            deleteConfigMapByLabelFunction;
     private final Function<String, CompletableFuture<Void>> deleteConfigMapFunction;
     private final Consumer<Void> closeConsumer;
     private final BiFunction<
@@ -71,7 +69,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                     KubernetesLeaderElector>
             createLeaderElectorFunction;
 
-    private final Function<Map<String, String>, KubernetesConfigMapSharedWatcher>
+    private final Function<String, KubernetesConfigMapSharedWatcher>
             createConfigMapSharedWatcherFunction;
 
     private TestingFlinkKubeClient(
@@ -88,7 +86,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                             Function<KubernetesConfigMap, Optional<KubernetesConfigMap>>,
                             CompletableFuture<Boolean>>
                     checkAndUpdateConfigMapFunction,
-            Function<Map<String, String>, CompletableFuture<Void>> deleteConfigMapByLabelFunction,
             Function<String, CompletableFuture<Void>> deleteConfigMapFunction,
             Consumer<Void> closeConsumer,
             BiFunction<
@@ -96,7 +93,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                             KubernetesLeaderElector.LeaderCallbackHandler,
                             KubernetesLeaderElector>
                     createLeaderElectorFunction,
-            Function<Map<String, String>, KubernetesConfigMapSharedWatcher>
+            Function<String, KubernetesConfigMapSharedWatcher>
                     createConfigMapSharedWatcherFunction) {
 
         this.createTaskManagerPodFunction = createTaskManagerPodFunction;
@@ -108,7 +105,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         this.createConfigMapFunction = createConfigMapFunction;
         this.getConfigMapFunction = getConfigMapFunction;
         this.checkAndUpdateConfigMapFunction = checkAndUpdateConfigMapFunction;
-        this.deleteConfigMapByLabelFunction = deleteConfigMapByLabelFunction;
         this.deleteConfigMapFunction = deleteConfigMapFunction;
 
         this.closeConsumer = closeConsumer;
@@ -183,19 +179,13 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public CompletableFuture<Void> deleteConfigMapsByLabels(Map<String, String> labels) {
-        return deleteConfigMapByLabelFunction.apply(labels);
-    }
-
-    @Override
     public CompletableFuture<Void> deleteConfigMap(String configMapName) {
         return deleteConfigMapFunction.apply(configMapName);
     }
 
     @Override
-    public KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(
-            Map<String, String> labels) {
-        return createConfigMapSharedWatcherFunction.apply(labels);
+    public KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(String name) {
+        return createConfigMapSharedWatcherFunction.apply(name);
     }
 
     @Override
@@ -241,8 +231,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                         CompletableFuture<Boolean>>
                 checkAndUpdateConfigMapFunction =
                         (ignore1, ignore2) -> CompletableFuture.completedFuture(true);
-        private Function<Map<String, String>, CompletableFuture<Void>>
-                deleteConfigMapByLabelFunction = (ignore) -> FutureUtils.completedVoidFuture();
         private Function<String, CompletableFuture<Void>> deleteConfigMapFunction =
                 (ignore) -> FutureUtils.completedVoidFuture();
 
@@ -254,7 +242,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                         KubernetesLeaderElector>
                 createLeaderElectorFunction = TestingKubernetesLeaderElector::new;
 
-        private Function<Map<String, String>, KubernetesConfigMapSharedWatcher>
+        private Function<String, KubernetesConfigMapSharedWatcher>
                 createConfigMapSharedWatcherFunction = TestingKubernetesConfigMapSharedWatcher::new;
 
         private Builder() {}
@@ -318,13 +306,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
             return this;
         }
 
-        public Builder setDeleteConfigMapByLabelFunction(
-                Function<Map<String, String>, CompletableFuture<Void>>
-                        deleteConfigMapByLabelFunction) {
-            this.deleteConfigMapByLabelFunction = deleteConfigMapByLabelFunction;
-            return this;
-        }
-
         public Builder setDeleteConfigMapFunction(
                 Function<String, CompletableFuture<Void>> deleteConfigMapFunction) {
             this.deleteConfigMapFunction = deleteConfigMapFunction;
@@ -347,7 +328,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         }
 
         public Builder setCreateConfigMapSharedWatcherFunction(
-                Function<Map<String, String>, KubernetesConfigMapSharedWatcher>
+                Function<String, KubernetesConfigMapSharedWatcher>
                         createConfigMapSharedWatcherFunction) {
             this.createConfigMapSharedWatcherFunction = createConfigMapSharedWatcherFunction;
             return this;
@@ -363,7 +344,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                     createConfigMapFunction,
                     getConfigMapFunction,
                     checkAndUpdateConfigMapFunction,
-                    deleteConfigMapByLabelFunction,
                     deleteConfigMapFunction,
                     closeConsumer,
                     createLeaderElectorFunction,
@@ -454,7 +434,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         private BiFunction<String, WatchCallbackHandler<KubernetesConfigMap>, Watch> watchFunction =
                 (ignore1, ignore2) -> new MockKubernetesWatch();
 
-        public TestingKubernetesConfigMapSharedWatcher(Map<String, String> labels) {}
+        public TestingKubernetesConfigMapSharedWatcher(String name) {}
 
         public void setWatchFunction(
                 BiFunction<String, WatchCallbackHandler<KubernetesConfigMap>, Watch>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriver.java
@@ -28,7 +28,7 @@ package org.apache.flink.runtime.leaderelection;
  * <p><strong>Important</strong>: The {@link LeaderElectionDriver} could not guarantee that there is
  * no {@link LeaderElectionEventHandler} callbacks happen after {@link #close()}.
  */
-public interface LeaderElectionDriver {
+public interface LeaderElectionDriver extends AutoCloseable {
 
     /**
      * Write the current leader information to external persistent storage(e.g. Zookeeper,
@@ -49,7 +49,4 @@ public interface LeaderElectionDriver {
      * @return Return whether the driver has leadership.
      */
     boolean hasLeadership();
-
-    /** Close the services used for leader election. */
-    void close() throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/LeaderRetrievalDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/LeaderRetrievalDriver.java
@@ -25,8 +25,4 @@ package org.apache.flink.runtime.leaderretrieval;
  * <p><strong>Important</strong>: The {@link LeaderRetrievalDriver} could not guarantee that there
  * is no {@link LeaderRetrievalEventHandler} callbacks happen after {@link #close()}.
  */
-public interface LeaderRetrievalDriver {
-
-    /** Close the services used for leader retrieval. */
-    void close() throws Exception;
-}
+public interface LeaderRetrievalDriver extends AutoCloseable {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
@@ -31,7 +31,7 @@ import java.util.function.Consumer;
  * testing purposes.
  */
 public class TestingLeaderElectionEventHandler extends TestingLeaderBase
-        implements LeaderElectionEventHandler {
+        implements LeaderElectionEventHandler, AutoCloseable {
 
     private final Object lock = new Object();
 
@@ -135,6 +135,7 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
         }
     }
 
+    @Override
     public void close() {
         synchronized (lock) {
             running = false;

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkAssertions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkAssertions.java
@@ -25,6 +25,8 @@ import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.api.ThrowingConsumer;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -138,5 +140,30 @@ public final class FlinkAssertions {
             return Stream.of(throwable);
         }
         return Stream.concat(Stream.of(throwable), chainOfCauses(throwable.getCause()));
+    }
+
+    /**
+     * Create assertion for {@link java.util.concurrent.CompletableFuture}.
+     *
+     * @param actual the actual value.
+     * @param <T> the type of the value contained in the {@link
+     *     java.util.concurrent.CompletableFuture}.
+     * @return the created assertion object.
+     */
+    public static <T> FlinkCompletableFutureAssert<T> assertThatFuture(
+            CompletableFuture<T> actual) {
+        return new FlinkCompletableFutureAssert<>(actual);
+    }
+
+    /**
+     * Create assertion for {@link java.util.concurrent.CompletionStage}.
+     *
+     * @param actual the actual value.
+     * @param <T> the type of the value contained in the {@link
+     *     java.util.concurrent.CompletionStage}.
+     * @return the created assertion object.
+     */
+    public static <T> FlinkCompletableFutureAssert<T> assertThatFuture(CompletionStage<T> actual) {
+        return new FlinkCompletableFutureAssert<>(actual);
     }
 }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkCompletableFutureAssert.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkCompletableFutureAssert.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.testutils;
+
+import org.assertj.core.api.AbstractCompletableFutureAssert;
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ThrowableAssertAlternative;
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.internal.Failures;
+import org.assertj.core.internal.Objects;
+
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ * Enhanced version of {@link org.assertj.core.api.CompletableFutureAssert}, that allows asserting
+ * futures without relying on timeouts.
+ *
+ * @param <T> type of the value contained in the {@link CompletableFuture}.
+ */
+public class FlinkCompletableFutureAssert<T>
+        extends AbstractCompletableFutureAssert<FlinkCompletableFutureAssert<T>, T> {
+
+    private static final String SHOULD_HAVE_SUCCEEDED = "%nExpecting%n  <%s>%nto have succeeded.%n";
+
+    private static final String SHOULD_HAVE_FAILED = "%nExpecting%n  <%s>%nto have failed.%n";
+
+    /** A strongly typed alternative to {@link org.assertj.core.api.WithThrowable}. */
+    public static class WithThrowable {
+
+        private final Throwable throwable;
+
+        private WithThrowable(Throwable throwable) {
+            this.throwable = throwable;
+        }
+
+        /**
+         * Checks that the underlying throwable is of the given type and returns a {@link
+         * ThrowableAssertAlternative} to chain further assertions on the underlying throwable.
+         *
+         * @param type the expected {@link Throwable} type
+         * @param <T> the expected {@link Throwable} type
+         * @return a {@link ThrowableAssertAlternative} built with underlying throwable.
+         */
+        public <T extends Throwable> ThrowableAssertAlternative<T> withThrowableOfType(
+                Class<T> type) {
+            final ThrowableAssertAlternative<Throwable> throwableAssert =
+                    new ThrowableAssertAlternative<>(throwable).isInstanceOf(type);
+            @SuppressWarnings("unchecked")
+            final ThrowableAssertAlternative<T> cast =
+                    (ThrowableAssertAlternative<T>) throwableAssert;
+            return cast;
+        }
+    }
+
+    FlinkCompletableFutureAssert(CompletableFuture<T> actual) {
+        super(actual, FlinkCompletableFutureAssert.class);
+    }
+
+    FlinkCompletableFutureAssert(CompletionStage<T> actual) {
+        super(actual.toCompletableFuture(), FlinkCompletableFutureAssert.class);
+    }
+
+    /**
+     * An equivalent of {@link #succeedsWithin(Duration)}, that doesn't rely on timeouts.
+     *
+     * @return a new assertion object on the future's result
+     */
+    public ObjectAssert<T> eventuallySucceeds() {
+        final T object = assertEventuallySucceeds(info, actual);
+        return new ObjectAssert<>(object);
+    }
+
+    /**
+     * An equivalent of {@link #failsWithin(Duration)}, that doesn't rely on timeouts.
+     *
+     * @return a new assertion instance on the future's exception.
+     */
+    public WithThrowable eventuallyFails() {
+        return new WithThrowable(assertEventuallyFails(info, actual));
+    }
+
+    /**
+     * An equivalent of {@link #failsWithin(Duration)}, that doesn't rely on timeouts.
+     *
+     * @param exceptionClass type of the exception we expect the future to complete with
+     * @return a new assertion instance on the future's exception.
+     * @param <E> type of the exception we expect the future to complete with
+     */
+    public <E extends Throwable> ThrowableAssertAlternative<E> eventuallyFailsWith(
+            Class<E> exceptionClass) {
+        return eventuallyFails().withThrowableOfType(exceptionClass);
+    }
+
+    private T assertEventuallySucceeds(AssertionInfo info, Future<T> actual) {
+        Objects.instance().assertNotNull(info, actual);
+        try {
+            return actual.get();
+        } catch (InterruptedException | ExecutionException | CancellationException e) {
+            throw Failures.instance()
+                    .failure(info, new BasicErrorMessageFactory(SHOULD_HAVE_SUCCEEDED, actual));
+        }
+    }
+
+    private Exception assertEventuallyFails(AssertionInfo info, Future<?> actual) {
+        Objects.instance().assertNotNull(info, actual);
+        try {
+            actual.get();
+            throw Failures.instance()
+                    .failure(info, new BasicErrorMessageFactory(SHOULD_HAVE_FAILED, actual));
+        } catch (InterruptedException | ExecutionException | CancellationException e) {
+            return e;
+        }
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/FlinkAssertionsTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/FlinkAssertionsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.testutils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test suite for {@link FlinkAssertions}. */
+class FlinkAssertionsTest {
+
+    @Test
+    void testEventuallySucceedsWithCompletedFuture() {
+        final CompletableFuture<String> completedFuture =
+                CompletableFuture.completedFuture("Apache Flink");
+        assertThatFuture(completedFuture).eventuallySucceeds().isEqualTo("Apache Flink");
+    }
+
+    @Test
+    void testEventuallySucceedsWithFailedFuture() {
+        final CompletableFuture<String> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new IllegalStateException("Squirrel"));
+        assertThatThrownBy(() -> assertThatFuture(failedFuture).eventuallySucceeds())
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Squirrel");
+    }
+
+    @Test
+    void testEventuallySucceedsWithIncompleteFutureTimesOut() throws Exception {
+        assertWaitingForInterrupt(
+                () ->
+                        assertThatThrownBy(
+                                        () ->
+                                                assertThatFuture(new CompletableFuture<>())
+                                                        .eventuallySucceeds())
+                                .isInstanceOf(AssertionError.class),
+                Duration.ofMillis(10));
+    }
+
+    @Test
+    void testEventuallyFailsWithCompletedFuture() {
+        final CompletableFuture<String> completedFuture =
+                CompletableFuture.completedFuture("Apache Flink");
+        assertThatThrownBy(
+                        () ->
+                                assertThatFuture(completedFuture)
+                                        .eventuallyFailsWith(IllegalStateException.class))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Apache Flink");
+    }
+
+    @Test
+    void testEventuallyFailsWithFailedFuture() {
+        final CompletableFuture<String> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new IllegalStateException());
+        assertThatFuture(failedFuture)
+                .eventuallyFailsWith(ExecutionException.class)
+                .withCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testEventuallyFailsWithFailedFutureWithDifferentException() {
+        final CompletableFuture<String> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new IllegalStateException());
+        assertThatThrownBy(
+                        () ->
+                                assertThatFuture(failedFuture)
+                                        .eventuallyFailsWith(CancellationException.class))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("CancellationException");
+    }
+
+    @Test
+    void testEventuallyFailsWithIncompleteFutureTimesOut() throws Exception {
+        assertWaitingForInterrupt(
+                () ->
+                        assertThatFuture(new CompletableFuture<>())
+                                .eventuallyFails()
+                                .withThrowableOfType(InterruptedException.class),
+                Duration.ofMillis(10));
+    }
+
+    private static void assertWaitingForInterrupt(Runnable runnable, Duration timeout)
+            throws Exception {
+        final CheckedThread thread =
+                new CheckedThread() {
+                    @Override
+                    public void go() {
+                        runnable.run();
+                    }
+                };
+        thread.start();
+        Thread.sleep(timeout.toMillis());
+        assertThat(thread.isAlive()).isTrue();
+        thread.interrupt();
+        thread.sync();
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *[[FLINK-33598][k8s] Watch HA configmap via name instead of lables to r…](https://github.com/tongcheng-elong/flink/commit/aeae23b21afcbb26277380e59ff5d86c23aa2191)*
  - *[[FLINK-32368][test] Fixes wrong interface implementation in Kubernete…](https://github.com/tongcheng-elong/flink/commit/37a5c84d6e818703f34d085756941ba483da8e6f)*
  - *[[FLINK-31974] Do not crash jobmanager on Kubernetes client errors](https://github.com/tongcheng-elong/flink/commit/1699ba775cd36311c7d37aa309a28c7b011d7647)*
  - *[[FLINK-32010][kubernetes] Properly handle KubernetesLeaderRetrievalDr…](https://github.com/tongcheng-elong/flink/commit/9f61a13829a235dcef7e157ba6f1b8a588a41388)*
  - *[[FLINK-32010][runtime] Leader election/retrieval drivers should prope…](https://github.com/tongcheng-elong/flink/commit/580f4f2c514e6d707b5bc0e6d514265af39b47b2)*
 - *[[FLINK-32010][kubernetes] Rename KubernetesUtils#checkConfigMaps to K…](https://github.com/tongcheng-elong/flink/commit/2c518cb289e43ed00ed67a93687574a5c18c6c68)*
 - *[[FLINK-32010][kubernetes] Remove an unused parameter from KubernetesL…](https://github.com/tongcheng-elong/flink/commit/489b3883fbc2c04ca8a4e48089a2291a360cdfbd)*
 - *[[FLINK-31385] Introduce extended Assertj matchers for completable fut…](https://github.com/tongcheng-elong/flink/commit/8aba0c1194a4e89e64245b8e92f14b3575b16967)*
 - *[[FLINK-31652][k8s] Handle the deleted event in case pod is deleted du…](https://github.com/tongcheng-elong/flink/commit/85bafbac1cb05bea88dd2e1d74e234f79c59644a)*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
